### PR TITLE
Two small fixes

### DIFF
--- a/qtfred/CMakeLists.txt
+++ b/qtfred/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(qtfred ${EXE_GUI_TYPE}
     ${qtfred_QRC}
 )
 set_target_properties(qtfred PROPERTIES OUTPUT_NAME "qtfred_${FSO_BINARY_SUFFIX}")
+
+SET_TARGET_PROPERTIES(qtfred PROPERTIES DEBUG_POSTFIX "-DEBUG")
 target_compile_definitions(qtfred PRIVATE "$<$<CONFIG:RELEASE>:NDEBUG>;$<$<CONFIG:DEBUG>:_DEBUG;$<$<CXX_COMPILER_ID:MSVC>:PDB_DEBUGGING=1>>")
 
 add_definitions(-DFRED)

--- a/qtfred/src/renderwidget.cpp
+++ b/qtfred/src/renderwidget.cpp
@@ -64,6 +64,12 @@ void RenderWidget::resizeGL(int w, int h)
 
 void RenderWidget::keyPressEvent(QKeyEvent *key)
 {
+    if (key->isAutoRepeat())
+    {
+        QGLWidget::keyPressEvent(key);
+        return;
+    }
+
     if (!qt2fsKeys.count(key->key())) {
         QGLWidget::keyPressEvent(key);
         return;
@@ -75,13 +81,18 @@ void RenderWidget::keyPressEvent(QKeyEvent *key)
 
 void RenderWidget::keyReleaseEvent(QKeyEvent *key)
 {
+    if (key->isAutoRepeat())
+    {
+        QGLWidget::keyReleaseEvent(key);
+        return;
+    }
+
     if (!qt2fsKeys.count(key->key())) {
-        QGLWidget::keyPressEvent(key);
+        QGLWidget::keyReleaseEvent(key);
         return;
     }
 
     key->accept();
-    qDebug() << "Key" << qt2fsKeys.at(key->key());
     key_mark(qt2fsKeys.at(key->key()), 0, 0);
 }
 


### PR DESCRIPTION
1. Added CMake rule to append `-DEBUG` to debug builds
2. Changed renderwidget key handling to ignore auto-repeated events as that confuses the FSO key handling.
